### PR TITLE
Allow merge resolve plugins like config plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ jspm_packages
 
 # Webstorm project metadata
 .idea
+
+# macOS
+.DS_Store

--- a/src/Resolve.js
+++ b/src/Resolve.js
@@ -55,9 +55,14 @@ module.exports = class extends ChainedMap {
       'extensions',
       'mainFields',
       'mainFiles',
-      'modules',
-      'plugins',
+      'modules'
     ];
+
+    if (!omit.includes('plugin') && 'plugin' in obj) {
+      Object.keys(obj.plugin).forEach(name =>
+        this.plugin(name).merge(obj.plugin[name])
+      );
+    }
 
     omissions.forEach(key => {
       if (!omit.includes(key) && key in obj) {
@@ -65,6 +70,6 @@ module.exports = class extends ChainedMap {
       }
     });
 
-    return super.merge(obj, [...omit, ...omissions]);
+    return super.merge(obj, [...omit, ...omissions, 'plugin']);
   }
 };

--- a/src/Resolve.js
+++ b/src/Resolve.js
@@ -55,7 +55,7 @@ module.exports = class extends ChainedMap {
       'extensions',
       'mainFields',
       'mainFiles',
-      'modules'
+      'modules',
     ];
 
     if (!omit.includes('plugin') && 'plugin' in obj) {

--- a/test/Resolve.js
+++ b/test/Resolve.js
@@ -1,6 +1,16 @@
 import test from 'ava';
 import Resolve from '../src/Resolve';
 
+class StringifyPlugin {
+  constructor(...args) {
+    this.values = args;
+  }
+
+  apply() {
+    return JSON.stringify(this.values);
+  }
+}
+
 test('is Chainable', t => {
   const parent = { parent: true };
   const resolve = new Resolve(parent);
@@ -122,4 +132,26 @@ test('plugin with name', t => {
   resolve.plugin('alpha');
 
   t.is(resolve.plugins.get('alpha').name, 'alpha');
+});
+
+
+test('plugin empty', t => {
+  const resolve = new Resolve();
+  const instance = resolve
+    .plugin('stringify')
+    .use(StringifyPlugin)
+    .end();
+
+  t.is(instance, resolve);
+  t.true(resolve.plugins.has('stringify'));
+  t.deepEqual(resolve.plugins.get('stringify').get('args'), []);
+});
+
+test('plugin with args', t => {
+  const resolve = new Resolve();
+
+  resolve.plugin('stringify').use(StringifyPlugin, ['alpha', 'beta']);
+
+  t.true(resolve.plugins.has('stringify'));
+  t.deepEqual(resolve.plugins.get('stringify').get('args'), ['alpha', 'beta']);
 });

--- a/test/Resolve.js
+++ b/test/Resolve.js
@@ -134,7 +134,6 @@ test('plugin with name', t => {
   t.is(resolve.plugins.get('alpha').name, 'alpha');
 });
 
-
 test('plugin empty', t => {
   const resolve = new Resolve();
   const instance = resolve


### PR DESCRIPTION
When merging `config`s, we automatically do a deep merge on any `plugin` entries;   add this same logic to merging `resolve` plugins