### PR TITLE
Provide the same API for config.optimization.minimizer as config.plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,5 +44,3 @@ jspm_packages
 # Webstorm project metadata
 .idea
 
-# macOS
-.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -43,4 +43,3 @@ jspm_packages
 
 # Webstorm project metadata
 .idea
-

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ jspm_packages
 
 # Webstorm project metadata
 .idea
+
+# macOS
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -576,7 +576,7 @@ config.optimization
   .flagIncludedChunks(flagIncludedChunks)
   .mergeDuplicateChunks(mergeDuplicateChunks)
   .minimize(minimize)
-  .minimizer(minimizer)
+  .minimizer(plugin)
   .namedChunks(namedChunks)
   .namedModules(namedModules)
   .nodeEnv(nodeEnv)
@@ -590,6 +590,58 @@ config.optimization
   .sideEffects(sideEffects)
   .splitChunks(splitChunks)
   .usedExports(usedExports)
+```
+
+#### Config optimization minimizers
+
+```js
+// Backed at config.optimization.minimizers
+config.optimization
+  minimizer(name) : ChainedMap
+```
+
+#### Config optimization minimizers: adding
+
+_NOTE: Do not use `new` to create the minimizer plugin, as this will be done for you._
+
+```js
+config.optimization
+  .minimizer(name)
+  .use(WebpackPlugin, args)
+
+// Examples
+
+config.optimization
+  .minimizer('optimizeCSSAssets')
+  .use(OptimizeCSSAssetsPlugin, [{ cssProcessorOptions: { safe: true } }])
+
+```
+
+#### Config optimization minimizers: modify arguments
+
+```js
+config.optimization
+  .minimizer(name)
+  .tap(args => newArgs)
+
+// Example
+config
+  .minimizer('optimizeCSSAssets')
+  .tap(args => [...args, { cssProcessorOptions: { safe: false } }])
+```
+
+#### Config optimization minimizers: modify instantiation
+
+```js
+config.optimization
+  .minimizer(name)
+  .init((Plugin, args) => new Plugin(...args));
+```
+
+#### Config optimization minimizers: removing
+
+```js
+config.optimization.minimizers.delete(name)
 ```
 
 #### Config plugins

--- a/README.md
+++ b/README.md
@@ -576,7 +576,6 @@ config.optimization
   .flagIncludedChunks(flagIncludedChunks)
   .mergeDuplicateChunks(mergeDuplicateChunks)
   .minimize(minimize)
-  .minimizer(plugin)
   .namedChunks(namedChunks)
   .namedModules(namedModules)
   .nodeEnv(nodeEnv)
@@ -597,7 +596,7 @@ config.optimization
 ```js
 // Backed at config.optimization.minimizers
 config.optimization
-  minimizer(name) : ChainedMap
+  .minimizer(name) : ChainedMap
 ```
 
 #### Config optimization minimizers: adding
@@ -612,8 +611,14 @@ config.optimization
 // Examples
 
 config.optimization
-  .minimizer('optimizeCSSAssets')
+  .minimizer('css')
   .use(OptimizeCSSAssetsPlugin, [{ cssProcessorOptions: { safe: true } }])
+
+// Minimizer plugins can also be specified by their path, allowing the expensive require()s to be
+// skipped in cases where the plugin or webpack configuration won't end up being used.
+config.optimization
+  .minimizer('css')
+  .use(require.resolve('optimize-css-assets-webpack-plugin'), [{ cssProcessorOptions: { safe: true } }])
 
 ```
 
@@ -626,7 +631,7 @@ config.optimization
 
 // Example
 config
-  .minimizer('optimizeCSSAssets')
+  .minimizer('css')
   .tap(args => [...args, { cssProcessorOptions: { safe: false } }])
 ```
 

--- a/src/Config.js
+++ b/src/Config.js
@@ -125,7 +125,7 @@ module.exports = class extends ChainedMap {
         resolveLoader: this.resolveLoader.toConfig(),
         devServer: this.devServer.toConfig(),
         module: this.module.toConfig(),
-        optimization: this.optimization.entries(),
+        optimization: this.optimization.toConfig(),
         plugins: this.plugins.values().map(plugin => plugin.toConfig()),
         performance: this.performance.entries(),
         entry: Object.keys(entryPoints).reduce(

--- a/src/Optimization.js
+++ b/src/Optimization.js
@@ -27,11 +27,7 @@ module.exports = class extends ChainedMap {
   }
 
   minimizer(name) {
-    if (!this.minimizers.has(name)) {
-      this.minimizers.set(name, new Plugin(this, name));
-    }
-
-    return this.minimizers.get(name);
+    return this.minimizers.getOrCompute(name, () => new Plugin(this, name));
   }
 
   toConfig() {
@@ -43,20 +39,12 @@ module.exports = class extends ChainedMap {
   }
 
   merge(obj, omit = []) {
-    const omissions = [];
-
     if (!omit.includes('minimizer') && 'minimizer' in obj) {
       Object.keys(obj.minimizer).forEach(name =>
         this.minimizer(name).merge(obj.minimizer[name])
       );
     }
 
-    omissions.forEach(key => {
-      if (!omit.includes(key) && key in obj) {
-        this[key].merge(obj[key]);
-      }
-    });
-
-    return super.merge(obj, [...omit, ...omissions, 'minimizer']);
+    return super.merge(obj, [...omit, 'minimizer']);
   }
 };

--- a/src/Optimization.js
+++ b/src/Optimization.js
@@ -1,14 +1,15 @@
 const ChainedMap = require('./ChainedMap');
+const Plugin = require('./Plugin');
 
 module.exports = class extends ChainedMap {
   constructor(parent) {
     super(parent);
+    this.minimizers = new ChainedMap(this);
     this.extend([
       'concatenateModules',
       'flagIncludedChunks',
       'mergeDuplicateChunks',
       'minimize',
-      'minimizer',
       'namedChunks',
       'namedModules',
       'nodeEnv',
@@ -23,5 +24,39 @@ module.exports = class extends ChainedMap {
       'splitChunks',
       'usedExports',
     ]);
+  }
+
+  minimizer(name) {
+    if (!this.minimizers.has(name)) {
+      this.minimizers.set(name, new Plugin(this, name));
+    }
+
+    return this.minimizers.get(name);
+  }
+
+  toConfig() {
+    return this.clean(
+      Object.assign(this.entries() || {}, {
+        minimizer: this.minimizers.values().map(plugin => plugin.toConfig()),
+      })
+    );
+  }
+
+  merge(obj, omit = []) {
+    const omissions = [];
+
+    if (!omit.includes('minimizer') && 'minimizer' in obj) {
+      Object.keys(obj.minimizer).forEach(name =>
+        this.minimizer(name).merge(obj.minimizer[name])
+      );
+    }
+
+    omissions.forEach(key => {
+      if (!omit.includes(key) && key in obj) {
+        this[key].merge(obj[key]);
+      }
+    });
+
+    return super.merge(obj, [...omit, ...omissions, 'minimizer']);
   }
 };

--- a/test/Config.js
+++ b/test/Config.js
@@ -97,6 +97,9 @@ test('toConfig with values', t => {
     .node.set('__dirname', 'mock')
     .end()
     .optimization.nodeEnv('PRODUCTION')
+    .minimizer('stringify')
+    .use(StringifyPlugin)
+    .end()
     .end()
     .target('node')
     .plugin('stringify')
@@ -132,6 +135,7 @@ test('toConfig with values', t => {
     },
     optimization: {
       nodeEnv: 'PRODUCTION',
+      minimizer: [new StringifyPlugin()],
     },
     output: {
       path: 'build',

--- a/test/Optimization.js
+++ b/test/Optimization.js
@@ -1,6 +1,16 @@
 import test from 'ava';
 import Optimization from '../src/Optimization';
 
+class StringifyPlugin {
+  constructor(...args) {
+    this.values = args;
+  }
+
+  apply() {
+    return JSON.stringify(this.values);
+  }
+}
+
 test('is Chainable', t => {
   const parent = { parent: true };
   const optimization = new Optimization(parent);
@@ -18,4 +28,47 @@ test('shorthand methods', t => {
   });
 
   t.deepEqual(optimization.entries(), obj);
+});
+
+test('minimizer plugin empty', t => {
+  const optimization = new Optimization();
+  const instance = optimization
+    .minimizer('stringify')
+    .use(StringifyPlugin)
+    .end();
+
+  t.is(instance, optimization);
+  t.true(optimization.minimizers.has('stringify'));
+  t.deepEqual(optimization.minimizers.get('stringify').get('args'), []);
+});
+
+test('minimizer plugin with args', t => {
+  const optimization = new Optimization();
+
+  optimization.minimizer('stringify').use(StringifyPlugin, ['alpha', 'beta']);
+
+  t.true(optimization.minimizers.has('stringify'));
+  t.deepEqual(optimization.minimizers.get('stringify').get('args'), [
+    'alpha',
+    'beta',
+  ]);
+});
+
+test('optimization merge', t => {
+  const optimization = new Optimization();
+  const obj = {
+    minimizer: {
+      stringify: {
+        plugin: StringifyPlugin,
+        args: ['alpha', 'beta'],
+      },
+    },
+  };
+
+  t.is(optimization.merge(obj), optimization);
+  t.true(optimization.minimizers.has('stringify'));
+  t.deepEqual(optimization.minimizers.get('stringify').get('args'), [
+    'alpha',
+    'beta',
+  ]);
 });


### PR DESCRIPTION
The `config` section has special plugin logic that allows `.plugin(name).use(pluginclass)` and merge functionality.  

This pull request adds equivalent logic for optimization plugins (known as minimizers).     This allows the configuration of such plugins to be changed as part of a `neutrino` environment (with arguments overriden before the plugin is actually initialized). 

Fixes #95.