### PR TITLE
Use the Resolve API to define ResolveLoader according to webpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,31 +529,8 @@ config.resolve.mainFiles
 
 #### Config resolveLoader
 
-```js
-config.resolveLoader : ChainedMap
-```
-
-#### Config resolveLoader extensions
-
-```js
-config.resolveLoader.extensions : ChainedSet
-
-config.resolveLoader.extensions
-  .add(value)
-  .prepend(value)
-  .clear()
-```
-
-#### Config resolveLoader modules
-
-```js
-config.resolveLoader.modules : ChainedSet
-
-config.resolveLoader.modules
-  .add(value)
-  .prepend(value)
-  .clear()
-```
+The API for `config.resolveLoader` is identical to `config.resolve` with
+the following additions:
 
 #### Config resolveLoader moduleExtensions
 
@@ -1088,10 +1065,26 @@ config.merge({
   resolveLoader: {
     [key]: value,
 
+    alias: {
+      [key]: value
+    },
+    aliasFields: [...values],
+    descriptionFields: [...values],
     extensions: [...values],
+    mainFields: [...values],
+    mainFiles: [...values],
     modules: [...values],
     moduleExtensions: [...values],
-    packageMains: [...values]
+    packageMains: [...values],
+
+    plugin: {
+      [name]: {
+        plugin: WebpackPlugin,
+        args: [...args],
+        before,
+        after
+      }
+    }
   },
 
   module: {

--- a/src/ResolveLoader.js
+++ b/src/ResolveLoader.js
@@ -1,11 +1,9 @@
-const ChainedMap = require('./ChainedMap');
+const Resolve = require('./Resolve');
 const ChainedSet = require('./ChainedSet');
 
-module.exports = class extends ChainedMap {
+module.exports = class extends Resolve {
   constructor(parent) {
     super(parent);
-    this.extensions = new ChainedSet(this);
-    this.modules = new ChainedSet(this);
     this.moduleExtensions = new ChainedSet(this);
     this.packageMains = new ChainedSet(this);
   }
@@ -14,20 +12,16 @@ module.exports = class extends ChainedMap {
     return this.clean(
       Object.assign(
         {
-          extensions: this.extensions.values(),
-          modules: this.modules.values(),
           moduleExtensions: this.moduleExtensions.values(),
           packageMains: this.packageMains.values(),
         },
-        this.entries() || {}
+        super.toConfig()
       )
     );
   }
 
   merge(obj, omit = []) {
     const omissions = [
-      'extensions',
-      'modules',
       'moduleExtensions',
       'packageMains',
     ];


### PR DESCRIPTION
According to the webpack docs:

> This set of options is identical to the `resolve` property set above, but is used only to resolve webpack's loader packages.

This tells me that the `Resolve` API and the `ResolveLoader` API should actually be identical. According to the webpack schema, both `resolve` and `resolveLoader` are ref'd to the `resolve` definition:

https://github.com/webpack/webpack/blob/dfe6379052598a00f13bfa4f34ac73856ddf3dd0/schemas/WebpackOptions.json#L1668

This patch removes the custom `ResolveLoader` API and uses the `Resolve` API to drive it. It should not be breaking at all, and should only be a feature bump due to the addition of the `resolve` methods.

Fixes #97.