### PR TITLE
Use the Resolve API to define ResolveLoader according to webpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,31 +529,8 @@ config.resolve.mainFiles
 
 #### Config resolveLoader
 
-```js
-config.resolveLoader : ChainedMap
-```
-
-#### Config resolveLoader extensions
-
-```js
-config.resolveLoader.extensions : ChainedSet
-
-config.resolveLoader.extensions
-  .add(value)
-  .prepend(value)
-  .clear()
-```
-
-#### Config resolveLoader modules
-
-```js
-config.resolveLoader.modules : ChainedSet
-
-config.resolveLoader.modules
-  .add(value)
-  .prepend(value)
-  .clear()
-```
+The API for `config.resolveLoader` is identical to `config.resolve` with
+the following additions:
 
 #### Config resolveLoader moduleExtensions
 
@@ -1088,10 +1065,26 @@ config.merge({
   resolveLoader: {
     [key]: value,
 
+    alias: {
+      [key]: value
+    },
+    aliasFields: [...values],
+    descriptionFields: [...values],
     extensions: [...values],
+    mainFields: [...values],
+    mainFiles: [...values],
     modules: [...values],
     moduleExtensions: [...values],
-    packageMains: [...values]
+    packageMains: [...values],
+
+    plugin: {
+      [name]: {
+        plugin: WebpackPlugin,
+        args: [...args],
+        before,
+        after
+      }
+    }
   },
 
   module: {

--- a/src/ResolveLoader.js
+++ b/src/ResolveLoader.js
@@ -1,11 +1,9 @@
-const ChainedMap = require('./ChainedMap');
+const Resolve = require('./Resolve');
 const ChainedSet = require('./ChainedSet');
 
-module.exports = class extends ChainedMap {
+module.exports = class extends Resolve {
   constructor(parent) {
     super(parent);
-    this.extensions = new ChainedSet(this);
-    this.modules = new ChainedSet(this);
     this.moduleExtensions = new ChainedSet(this);
     this.packageMains = new ChainedSet(this);
   }
@@ -14,20 +12,16 @@ module.exports = class extends ChainedMap {
     return this.clean(
       Object.assign(
         {
-          extensions: this.extensions.values(),
-          modules: this.modules.values(),
           moduleExtensions: this.moduleExtensions.values(),
           packageMains: this.packageMains.values(),
         },
-        this.entries() || {}
+        super.toConfig()
       )
     );
   }
 
   merge(obj, omit = []) {
     const omissions = [
-      'extensions',
-      'modules',
       'moduleExtensions',
       'packageMains',
     ];

--- a/src/ResolveLoader.js
+++ b/src/ResolveLoader.js
@@ -21,10 +21,7 @@ module.exports = class extends Resolve {
   }
 
   merge(obj, omit = []) {
-    const omissions = [
-      'moduleExtensions',
-      'packageMains',
-    ];
+    const omissions = ['moduleExtensions', 'packageMains'];
 
     omissions.forEach(key => {
       if (!omit.includes(key) && key in obj) {

--- a/test/ResolveLoader.js
+++ b/test/ResolveLoader.js
@@ -8,6 +8,18 @@ test('is Chainable', t => {
   t.is(resolveLoader.end(), parent);
 });
 
+test('shorthand methods', t => {
+  const resolveLoader = new ResolveLoader();
+  const obj = {};
+
+  resolveLoader.shorthands.forEach(method => {
+    obj[method] = 'alpha';
+    t.is(resolveLoader[method]('alpha'), resolveLoader);
+  });
+
+  t.deepEqual(resolveLoader.entries(), obj);
+});
+
 test('sets methods', t => {
   const resolveLoader = new ResolveLoader();
   const instance = resolveLoader.modules.add('src').end();
@@ -87,4 +99,12 @@ test('merge with omit', t => {
     modules: ['src', 'dist'],
     moduleExtensions: ['-loader'],
   });
+});
+
+test('plugin with name', t => {
+  const resolveLoader = new ResolveLoader();
+
+  resolveLoader.plugin('alpha');
+
+  t.is(resolveLoader.plugins.get('alpha').name, 'alpha');
 });


### PR DESCRIPTION
According to the webpack docs:

> This set of options is identical to the `resolve` property set above, but is used only to resolve webpack's loader packages.

This tells me that the `Resolve` API and the `ResolveLoader` API should actually be identical. According to the webpack schema, both `resolve` and `resolveLoader` are ref'd to the `resolve` definition:

https://github.com/webpack/webpack/blob/dfe6379052598a00f13bfa4f34ac73856ddf3dd0/schemas/WebpackOptions.json#L1668

This should not be breaking at all, and should only be a feature bump due to the addition of the `resolve` methods. The only reason we aren't just new-ing a `Resolve` in `Config` is that there are some legacy methods that would cause a breaking change if removed.

Fixes #97.