### PR TITLE
Fix toString() output for alternative types of plugin

### DIFF
--- a/src/Config.js
+++ b/src/Config.js
@@ -52,7 +52,7 @@ module.exports = class extends ChainedMap {
       (value, indent, stringify) => {
         // improve plugin output
         if (value && value.__pluginName) {
-          const prefix = `/* ${configPrefix}.plugin('${
+          const prefix = `/* ${configPrefix}.${value.__pluginType}('${
             value.__pluginName
           }') */\n`;
           const constructorExpression = value.__pluginPath

--- a/src/Optimization.js
+++ b/src/Optimization.js
@@ -27,7 +27,10 @@ module.exports = class extends ChainedMap {
   }
 
   minimizer(name) {
-    return this.minimizers.getOrCompute(name, () => new Plugin(this, name));
+    return this.minimizers.getOrCompute(
+      name,
+      () => new Plugin(this, name, 'optimization.minimizer')
+    );
   }
 
   toConfig() {

--- a/src/Plugin.js
+++ b/src/Plugin.js
@@ -3,9 +3,10 @@ const Orderable = require('./Orderable');
 
 module.exports = Orderable(
   class extends ChainedMap {
-    constructor(parent, name) {
+    constructor(parent, name, type = 'plugin') {
       super(parent);
       this.name = name;
+      this.type = type;
       this.extend(['init']);
 
       this.init((Plugin, args = []) => {
@@ -60,6 +61,7 @@ module.exports = Orderable(
 
       Object.defineProperties(config, {
         __pluginName: { value: this.name },
+        __pluginType: { value: this.type },
         __pluginArgs: { value: args },
         __pluginConstructorName: { value: constructorName },
         __pluginPath: { value: pluginPath },

--- a/src/Resolve.js
+++ b/src/Resolve.js
@@ -25,7 +25,10 @@ module.exports = class extends ChainedMap {
   }
 
   plugin(name) {
-    return this.plugins.getOrCompute(name, () => new Plugin(this, name));
+    return this.plugins.getOrCompute(
+      name,
+      () => new Plugin(this, name, 'resolve.plugin')
+    );
   }
 
   toConfig() {

--- a/test/Config.js
+++ b/test/Config.js
@@ -411,10 +411,19 @@ test('toString', t => {
     .plugin('epsilon')
     .use(class BazPlugin {}, [{ n: 1 }, [2, 3]]);
 
+  config.resolve.plugin('resolver').use(FooPlugin);
+  config.optimization.minimizer('minifier').use(FooPlugin);
+
   t.is(
     config.toString().trim(),
     `
 {
+  resolve: {
+    plugins: [
+      /* config.resolve.plugin('resolver') */
+      new (require('foo-plugin'))()
+    ]
+  },
   module: {
     rules: [
       /* config.module.rule('alpha') */
@@ -431,6 +440,12 @@ test('toString', t => {
           }
         ]
       }
+    ]
+  },
+  optimization: {
+    minimizer: [
+      /* config.optimization.minimizer('minifier') */
+      new (require('foo-plugin'))()
     ]
   },
   plugins: [

--- a/test/Optimization.js
+++ b/test/Optimization.js
@@ -30,6 +30,14 @@ test('shorthand methods', t => {
   t.deepEqual(optimization.entries(), obj);
 });
 
+test('minimizer plugin with name', t => {
+  const optimization = new Optimization();
+  optimization.minimizer('alpha');
+
+  t.is(optimization.minimizers.get('alpha').name, 'alpha');
+  t.is(optimization.minimizers.get('alpha').type, 'optimization.minimizer');
+});
+
 test('minimizer plugin empty', t => {
   const optimization = new Optimization();
   const instance = optimization
@@ -71,4 +79,29 @@ test('optimization merge', t => {
     'alpha',
     'beta',
   ]);
+});
+
+test('toConfig empty', t => {
+  const optimization = new Optimization();
+
+  t.deepEqual(optimization.toConfig(), {});
+});
+
+test('toConfig with values', t => {
+  const optimization = new Optimization();
+
+  optimization
+    .minimizer('foo')
+    .use(StringifyPlugin)
+    .end()
+    .splitChunks({
+      chunks: 'all',
+    });
+
+  t.deepEqual(optimization.toConfig(), {
+    minimizer: [new StringifyPlugin()],
+    splitChunks: {
+      chunks: 'all',
+    },
+  });
 });

--- a/test/Plugin.js
+++ b/test/Plugin.js
@@ -68,8 +68,16 @@ test('toConfig', t => {
   t.true(initialized instanceof StringifyPlugin);
   t.deepEqual(initialized.values, ['delta']);
   t.is(initialized.__pluginName, 'gamma');
+  t.is(initialized.__pluginType, 'plugin');
   t.deepEqual(initialized.__pluginArgs, ['delta']);
   t.is(initialized.__pluginConstructorName, 'StringifyPlugin');
+});
+
+test('toConfig with custom type', t => {
+  const plugin = new Plugin(null, 'gamma', 'optimization.minimizer');
+  plugin.use(StringifyPlugin);
+
+  t.is(plugin.toConfig().__pluginType, 'optimization.minimizer');
 });
 
 test('toConfig with custom expression', t => {

--- a/test/Resolve.js
+++ b/test/Resolve.js
@@ -50,14 +50,18 @@ test('toConfig empty', t => {
 test('toConfig with values', t => {
   const resolve = new Resolve();
 
-  resolve.modules
-    .add('src')
+  resolve
+    .plugin('stringify')
+    .use(StringifyPlugin)
+    .end()
+    .modules.add('src')
     .end()
     .extensions.add('.js')
     .end()
     .alias.set('React', 'src/react');
 
   t.deepEqual(resolve.toConfig(), {
+    plugins: [new StringifyPlugin()],
     modules: ['src'],
     extensions: ['.js'],
     alias: { React: 'src/react' },
@@ -132,6 +136,7 @@ test('plugin with name', t => {
   resolve.plugin('alpha');
 
   t.is(resolve.plugins.get('alpha').name, 'alpha');
+  t.is(resolve.plugins.get('alpha').type, 'resolve.plugin');
 });
 
 test('plugin empty', t => {


### PR DESCRIPTION
Previously the helper comments in the `toString()` output were incorrect for alternative forms of plugins (`optimization.minimizer` and `resolve.plugins`) and would refer to them as though they were instances of `config.plugins` instead.

Before:

`/* config.plugin('name') */`

After:

`/* config.optimization.minimizer('name') */`
`/* config.resolve.plugin('name') */`

Fixes #115.