### PR TITLE
feat: Support config.name() setter

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@ config
   .context(context)
   .externals(externals)
   .loader(loader)
+  .name(name)
   .mode(mode)
   .parallelism(parallelism)
   .profile(profile)

--- a/src/Config.js
+++ b/src/Config.js
@@ -31,6 +31,7 @@ module.exports = class extends ChainedMap {
       'externals',
       'loader',
       'mode',
+      'name',
       'parallelism',
       'profile',
       'recordsInputPath',


### PR DESCRIPTION
`name` is also a top-level option in webpack config. This PR add `config.name()` setter for more elegant usage.  