### PR TITLE
Update `config.mode` type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -56,7 +56,7 @@ declare class Config extends __Config.ChainedMap<void> {
   externals(value: webpack.ExternalsElement | webpack.ExternalsElement[]): this;
   loader(value: any): this;
   name(value: string): this;
-  mode(value: 'development' | 'production') : this;
+  mode(value: 'none' | 'development' | 'production') : this;
   parallelism(value: number) : this;
   profile(value: boolean): this;
   recordsPath(value: string): this;

--- a/types/test/webpack-chain-tests.ts
+++ b/types/test/webpack-chain-tests.ts
@@ -22,6 +22,7 @@ config
   .externals((context, request, cb) => cb(null, true))
   .loader({})
   .name("config-name")
+  .mode("none")
   .mode("development")
   .mode("production")
   .profile(false)


### PR DESCRIPTION
According to official documents of webpack, `config.mode` can be `none` in addition to `development` and `production`.

Refs: https://webpack.js.org/concepts/mode/