### PR TITLE
optimize type definitions for ResolveLoader

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -198,11 +198,9 @@ declare namespace Config {
     plugin(name: string): Plugin<this>;
   }
 
-  class ResolveLoader extends ChainedMap<Config> {
-    extensions: TypedChainedSet<this, string>;
-    modules: TypedChainedSet<this, string>;
-    moduleExtensions: TypedChainedSet<this, string>;
-    packageMains: TypedChainedSet<this, string>;
+  class ResolveLoader extends Resolve {
+    moduleExtensions: ChainedSet<this>;
+    packageMains: ChainedSet<this>
   }
 
   class Rule extends ChainedMap<Module> {

--- a/types/test/webpack-chain-tests.ts
+++ b/types/test/webpack-chain-tests.ts
@@ -128,6 +128,9 @@ config
     .packageMains
       .add('index.js')
       .end()
+    .plugin('foo')
+      .use(webpack.DefinePlugin)
+      .end()
     .end()
 
   .performance


### PR DESCRIPTION
**Why**

I'm trying to add [pnp-webpack-plugin](https://github.com/arcanis/pnp-webpack-plugin) to my project. It needs add plugin to **resolveLoader**. But I go a type error:

```
Property 'plugin' does not exist on type 'ResolveLoader'.ts(2339)
```

I checked webpack-chain's source and find `ResolveLoader` extends `Resolve` in source code but not in type definitions.

So I updated code and created this PR. Please let me know if any problem.