### PR TITLE
make __expression property works in any object

### DIFF
--- a/README.md
+++ b/README.md
@@ -1043,7 +1043,7 @@ config.module
       .use('vue-style')
         .loader('vue-style-loader')
         .end()
-      .end()    
+      .end()
     .oneOf('normal')
       .use('sass')
         .loader('sass-loader')
@@ -1315,11 +1315,14 @@ config.toString();
 ```
 
 By default the generated string cannot be used directly as real webpack config
-if it contains functions and plugins that need to be required. In order to
-generate usable config, you can customize how functions and plugins are
+if it contains objects and plugins that need to be required. In order to
+generate usable config, you can customize how objects and plugins are
 stringified by setting a special `__expression` property on them:
 
 ``` js
+const sass = require('sass');
+sass.__expression = `require('sass');
+
 class MyPlugin {}
 MyPlugin.__expression = `require('my-plugin')`;
 
@@ -1328,7 +1331,7 @@ myFunction.__expression = `require('my-function')`;
 
 config
   .plugin('example')
-    .use(MyPlugin, [{ fn: myFunction }]);
+    .use(MyPlugin, [{ fn: myFunction, implementation: sass, }]);
 
 config.toString();
 
@@ -1336,7 +1339,8 @@ config.toString();
 {
   plugins: [
     new (require('my-plugin'))({
-      fn: require('my-function')
+      fn: require('my-function'),
+      implementation: require('sass')
     })
   ]
 }

--- a/src/Config.js
+++ b/src/Config.js
@@ -91,11 +91,12 @@ module.exports = class extends ChainedMap {
           return prefix + stringify(value);
         }
 
+        if (value && value.__expression) {
+          return value.__expression;
+        }
+
         // shorten long functions
         if (typeof value === 'function') {
-          if (value.__expression) {
-            return value.__expression;
-          }
           if (!verbose && value.toString().length > 100) {
             return `function () { /* omitted long function */ }`;
           }

--- a/test/Config.js
+++ b/test/Config.js
@@ -524,6 +524,10 @@ test('toString with custom prefix', t => {
 
 test('static Config.toString', t => {
   const config = new Config();
+  const sass = {
+    __expression: `require('sass')`,
+    render() {},
+  };
 
   config.plugin('foo').use(class TestPlugin {});
 
@@ -536,7 +540,10 @@ test('static Config.toString', t => {
               use: [
                 {
                   loader: 'banner-loader',
-                  options: { prefix: 'banner-prefix.txt' },
+                  options: {
+                    prefix: 'banner-prefix.txt',
+                    implementation: sass,
+                  },
                 },
               ],
             },
@@ -557,7 +564,8 @@ test('static Config.toString', t => {
           {
             loader: 'banner-loader',
             options: {
-              prefix: 'banner-prefix.txt'
+              prefix: 'banner-prefix.txt',
+              implementation: require('sass')
             }
           }
         ]


### PR DESCRIPTION
Because [sass-loader](https://github.com/webpack-contrib/sass-loader) support custom Sass implementation, and `dart-sass` implementation is an object, so I hope `__expression` can works in any object