### PR TITLE
Fix types for Config.resolve plugins and improve Plugin types

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     "javascript-stringify": "^2.0.0"
   },
   "devDependencies": {
+    "@types/enhanced-resolve": "^3.0.6",
     "@types/node": "^12.7.2",
+    "@types/tapable": "^1.0.4",
     "@types/webpack": "^4.32.2",
     "auto-changelog": "^1.15.0",
     "ava": "^1.4.1",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,3 +1,4 @@
+import {Tapable} from 'tapable';
 import * as webpack from 'webpack';
 import * as https from 'https';
 
@@ -44,7 +45,7 @@ declare class Config extends __Config.ChainedMap<void> {
   output: Config.Output;
   optimization: Config.Optimization;
   performance: Config.Performance;
-  plugins: Config.Plugins<this>;
+  plugins: Config.Plugins<this, webpack.Plugin>;
   resolve: Config.Resolve;
   resolveLoader: Config.ResolveLoader;
 
@@ -68,7 +69,7 @@ declare class Config extends __Config.ChainedMap<void> {
   watchOptions(value: webpack.Options.WatchOptions): this;
 
   entry(name: string): Config.EntryPoint;
-  plugin(name: string): Config.Plugin<this>;
+  plugin(name: string): Config.Plugin<this, webpack.Plugin>;
 
   toConfig(): webpack.Configuration;
 }
@@ -80,11 +81,11 @@ declare namespace Config {
   class TypedChainedSet<Parent, Value> extends __Config.TypedChainedSet<Parent, Value> {}
   class ChainedSet<Parent> extends __Config.TypedChainedSet<Parent, any> {}
 
-  class Plugins<Parent> extends TypedChainedMap<Parent, Plugin<Parent>> {}
+  class Plugins<Parent, PluginType extends Tapable.Plugin = webpack.Plugin> extends TypedChainedMap<Parent, Plugin<Parent, PluginType>> {}
 
-  class Plugin<Parent> extends ChainedMap<Parent> implements Orderable {
-    init(value: (plugin: PluginClass, args: any[]) => webpack.Plugin): this;
-    use(plugin: PluginClass, args?: any[]): this;
+  class Plugin<Parent, PluginType extends Tapable.Plugin = webpack.Plugin> extends ChainedMap<Parent> implements Orderable {
+    init(value: (plugin: PluginClass<PluginType>, args: any[]) => PluginType): this;
+    use(plugin: PluginClass<PluginType>, args?: any[]): this;
     tap(f: (args: any[]) => any[]): this;
 
     // Orderable
@@ -186,7 +187,7 @@ declare namespace Config {
     mainFields: TypedChainedSet<this, string>;
     mainFiles: TypedChainedSet<this, string>;
     modules: TypedChainedSet<this, string>;
-    plugins: TypedChainedMap<this, Plugin<this>>;
+    plugins: TypedChainedMap<this, Plugin<this, webpack.ResolvePlugin>>;
 
     enforceExtension(value: boolean): this;
     enforceModuleExtension(value: boolean): this;
@@ -195,7 +196,7 @@ declare namespace Config {
     cachePredicate(value: (data: { path: string, request: string }) => boolean): this;
     cacheWithContext(value: boolean): this;
 
-    plugin(name: string): Plugin<this>;
+    plugin(name: string): Plugin<this, webpack.ResolvePlugin>;
   }
 
   class ResolveLoader extends Resolve {
@@ -225,7 +226,7 @@ declare namespace Config {
     flagIncludedChunks(value: boolean): this;
     mergeDuplicateChunks(value: boolean): this;
     minimize(value: boolean): this;
-    minimizer(name: string): Config.Plugin<this>;
+    minimizer(name: string): Config.Plugin<this, webpack.Plugin>;
     namedChunks(value: boolean): this;
     namedModules(value: boolean): this;
     nodeEnv(value: boolean | string): this;
@@ -285,8 +286,8 @@ declare namespace Config {
     '#@source-map' | '#@nosources-source-map' | '#@hidden-source-map' | '#@nosources-source-map' |
     boolean;
 
-  interface PluginClass {
-    new (...opts: any[]): webpack.Plugin;
+  interface PluginClass<PluginType extends Tapable.Plugin = webpack.Plugin> {
+    new (...opts: any[]): PluginType;
   }
 
   interface Orderable {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -84,8 +84,8 @@ declare namespace Config {
   class Plugins<Parent, PluginType extends Tapable.Plugin = webpack.Plugin> extends TypedChainedMap<Parent, Plugin<Parent, PluginType>> {}
 
   class Plugin<Parent, PluginType extends Tapable.Plugin = webpack.Plugin> extends ChainedMap<Parent> implements Orderable {
-    init(value: (plugin: PluginClass<PluginType>, args: any[]) => PluginType): this;
-    use(plugin: PluginClass<PluginType>, args?: any[]): this;
+    init(value: (plugin: PluginType | PluginClass<PluginType>, args: any[]) => PluginType): this;
+    use(plugin: string | PluginType | PluginClass<PluginType>, args?: any[]): this;
     tap(f: (args: any[]) => any[]): this;
 
     // Orderable

--- a/types/test/webpack-chain-tests.ts
+++ b/types/test/webpack-chain-tests.ts
@@ -185,10 +185,20 @@ config
     .after('bar')
     .end()
 
+  .plugin('asString')
+    .use('package-name-or-path')
+    .end()
+
+  .plugin('asObject')
+    .use({ apply: (compiler: webpack.Compiler) => {}})
+    .end()
+
   .plugins
     .delete('foo')
     .delete('bar')
     .delete('baz')
+    .delete('asString')
+    .delete('asObject')
     .end()
 
   .node

--- a/types/test/webpack-chain-tests.ts
+++ b/types/test/webpack-chain-tests.ts
@@ -2,8 +2,13 @@
  * Notes: The order structure of the type check follows the order
  * of this document: https://github.com/neutrinojs/webpack-chain#config
  */
+import Resolver = require('enhanced-resolve/lib/Resolver');
 import Config = require('webpack-chain');
 import * as webpack from 'webpack';
+
+class ResolvePluginImpl extends webpack.ResolvePlugin {
+  apply(resolver: Resolver): void {}
+}
 
 const config = new Config();
 
@@ -114,7 +119,7 @@ config
       .add('index.js')
       .end()
     .plugin('foo')
-      .use(webpack.DefinePlugin, [])
+      .use(ResolvePluginImpl, [])
       .end()
     .plugins
       .delete('foo')

--- a/yarn.lock
+++ b/yarn.lock
@@ -331,6 +331,14 @@
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"
   integrity sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==
 
+"@types/enhanced-resolve@^3.0.6":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@types/enhanced-resolve/-/enhanced-resolve-3.0.6.tgz#a51eaa24f4458ed13fb42a7048c0b66f92e95a28"
+  integrity sha512-mAWc6JpDiA6GnPCF5023YSGMa/E7baMvLs+HtT9E6Z52lUds3pthf4APhVQpbmV6sZTrbASgBEDdh70eGWTJFw==
+  dependencies:
+    "@types/node" "*"
+    "@types/tapable" "^0"
+
 "@types/events@*":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
@@ -360,10 +368,15 @@
   resolved "https://registry.yarnpkg.com/@types/source-list-map/-/source-list-map-0.1.2.tgz#0078836063ffaf17412349bba364087e0ac02ec9"
   integrity sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==
 
-"@types/tapable@*":
+"@types/tapable@*", "@types/tapable@^1.0.4":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.4.tgz#b4ffc7dc97b498c969b360a41eee247f82616370"
   integrity sha512-78AdXtlhpCHT0K3EytMpn4JNxaf5tbqbLcbIRoQIHzpTIyjpxLQKRoxU55ujBXAtg3Nl2h/XWvfDa9dsMOd0pQ==
+
+"@types/tapable@^0":
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-0.2.5.tgz#2443fc12da514c81346b1a665675559cee21fa75"
+  integrity sha512-dEoVvo/I9QFomyhY+4Q6Qk+I+dhG59TYceZgC6Q0mCifVPErx6Y83PNTKGDS5e9h9Eti6q0S2mm16BU6iQK+3w==
 
 "@types/uglify-js@*":
   version "3.0.4"


### PR DESCRIPTION
- Fixes `Config.resolve.plugin` call expecting a `webpack.Plugin` type despite those plugins being passed an `enhanced-resolve/lib/Resolver` argument type. (As seen in [this test](https://github.com/webpack/webpack/blob/157c457241bf46b1cb31dbb17e806702eb4a0ec5/test/statsCases/resolve-plugin-context/ResolvePackageFromRootPlugin.js) which uses it as a [resolve plugin](https://github.com/webpack/webpack/blob/157c457241bf46b1cb31dbb17e806702eb4a0ec5/test/statsCases/resolve-plugin-context/webpack.config.js#L10))

    - All added generics default to `webpack.Plugin` in order to stay fully backwards compatible with previous versions.

- Allows passing `string` to `Plugin.use()` as those get required by `webpack-chain` [here](https://github.com/neutrinojs/webpack-chain/blob/c59f853e7164f0acac9970c230a35500a1e5cbd3/src/Plugin.js#L50).

- Allows passing `PluginType` to `Plugin.use()` and `Plugin.init()` as the [default implementation allows it](https://github.com/neutrinojs/webpack-chain/blob/master/src/Plugin.js#L12).

- Adds tests for the changes.

    - To make that possible, `@types/enhanced-resolve` and `@types/tapable` were added to `devDependencies` to allow the tests to work.

    - The `webpack.ResolvePlugin` type currently uses `any` as the `apply()` argument type. The tests use the `Resolver` type to future-proof.

        - As it turns out the reason is that the DefinitelyTyped `enhanced-resolve` types are a major behind, so the DefinitelyTyped types for `webpack` simply don't reference them. They can't be reused either, as `enhanced-resolve` v3 uses `tapable` v0 while `enhanced-resolve` v4 uses `tapable` v1. See DefinitelyTyped/DefinitelyTyped#40804

        - Meanwhile, the official webpack types are also invalid. I created an issue on the official webpack repo to track that: webpack/webpack#10073.