### PR TITLE
Fix types for Oneof

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -263,7 +263,7 @@ declare namespace Config {
     after(name: string): this;
   }
 
-  class OneOf extends ChainedMap<Rule> implements Orderable {
+  class OneOf extends Rule implements Orderable {
     resourceQuery(value: webpack.Condition | webpack.Condition[]): this;
     use(name: string): Use<this>;
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -205,7 +205,7 @@ declare namespace Config {
   }
 
   class Rule extends ChainedMap<Module> {
-    oneOfs: TypedChainedMap<this, OneOf>;
+    oneOfs: TypedChainedMap<this, ChildRule>;
     uses: TypedChainedMap<this, Use>;
     include: TypedChainedSet<this, webpack.Condition>;
     exclude: TypedChainedSet<this, webpack.Condition>;
@@ -216,7 +216,7 @@ declare namespace Config {
     enforce(value: 'pre' | 'post'): this;
 
     use(name: string): Use;
-    oneOf(name: string): OneOf;
+    oneOf(name: string): ChildRule;
     pre(): this;
     post(): this;
   }
@@ -263,7 +263,7 @@ declare namespace Config {
     after(name: string): this;
   }
 
-  class OneOf extends Rule implements Orderable {
+  class OneOf extends ChainedMap<Rule> implements Orderable {
     resourceQuery(value: webpack.Condition | webpack.Condition[]): this;
     use(name: string): Use<this>;
 
@@ -271,6 +271,8 @@ declare namespace Config {
     before(name: string): this;
     after(name: string): this;
   }
+
+  type ChildRule = OneOf & Rule;
 
   type DevTool = 'eval' | 'inline-source-map' | 'cheap-eval-source-map' | 'cheap-source-map' |
     'cheap-module-eval-source-map' | 'cheap-module-source-map' | 'eval-source-map' | 'source-map' |

--- a/types/test/webpack-chain-tests.ts
+++ b/types/test/webpack-chain-tests.ts
@@ -293,6 +293,9 @@ config
       .post()
       .oneOf('inline')
         .after('vue')
+        .uses
+          .delete('babel')
+          .end()
         .resourceQuery(/inline/)
         .use('url')
           .loader('url-loader')


### PR DESCRIPTION
In code, the typeof Oneof is new Rule, someone (like me) may use code like
```javascript
const rule = webpackConfig.module.rule(lang).oneOf(type);
rule.uses.delete('something')
```

And I check the typing file, Type Oneof is not extends from Rule：https://github.com/neutrinojs/webpack-chain/blob/master/src/Rule.js#L40