### PR TITLE
docs: Correct the .merge() example for optimization.minimizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1230,7 +1230,14 @@ config.merge({
     flagIncludedChunks,
     mergeDuplicateChunks,
     minimize,
-    minimizer,
+    minimizer: {
+      [name]: {
+        plugin: WebpackPlugin,
+        args: [...args],
+        before,
+        after
+      }
+    },
     namedChunks,
     namedModules,
     nodeEnv,


### PR DESCRIPTION
Since as of #84 (which was released in webpack-chain 5.0.0), the `optimization.minimizer` entries in the data structure passed to `.merge()` must match that of the other plugin-like configuration.

Refs #204.