### PR TITLE
Improve error message when legacy minimizer syntax used

### DIFF
--- a/src/Optimization.js
+++ b/src/Optimization.js
@@ -27,6 +27,14 @@ module.exports = class extends ChainedMap {
   }
 
   minimizer(name) {
+    if (Array.isArray(name)) {
+      throw new Error(
+        'optimization.minimizer() no longer supports being passed an array. ' +
+          'Either switch to the new syntax (https://github.com/neutrinojs/webpack-chain#config-optimization-minimizers-adding) or downgrade to webpack-chain 4. ' +
+          'If using Vue this likely means a Vue plugin has not yet been updated to support Vue CLI 4+.',
+      );
+    }
+
     return this.minimizers.getOrCompute(
       name,
       () => new Plugin(this, name, 'optimization.minimizer'),

--- a/test/Optimization.js
+++ b/test/Optimization.js
@@ -62,6 +62,14 @@ test('minimizer plugin with args', t => {
   ]);
 });
 
+test('minimizer plugin legacy syntax', t => {
+  const optimization = new Optimization();
+  t.throws(
+    () => optimization.minimizer([new StringifyPlugin()]),
+    /optimization.minimizer\(\) no longer supports being passed an array/,
+  );
+});
+
 test('optimization merge', t => {
   const optimization = new Optimization();
   const obj = {


### PR DESCRIPTION
In #84 (released as part of webpack-chain 5.0.0) the syntax for using `optimization.minimizer` was altered, so that it matched that for `plugin`, `resolve.plugin` and `resolveLoader.plugin`.

Syntax in webpack-chain 4:

```js
config.optimization.minimizer([
  new WebpackPluginFoo(),
  new WebpackPluginBar(arg1, arg2),
]);
```

Syntax in webpack-chain 5+ ([full docs](https://github.com/neutrinojs/webpack-chain#config-optimization-minimizers-adding)):

```js
config.optimization.minimizer('foo').use(WebpackPluginFoo);
config.optimization.minimizer('bar').use(WebpackPluginBar, [arg1, arg2]);
```

Currently if someone uses the old syntax with newer webpack-chain, then the `minimizer()` call succeeds, but later when `.toConfig()` is called, the following error is generated:

`TypeError: Cannot read property '__expression' of undefined`

This PR adds an explicit check to `optimization.minimizer()` which ensures a clearer error message is shown at point of use, so that the stack trace is more relevant, and root cause clearer:

> `optimization.minimizer()` no longer supports being passed an array. Either switch to the new syntax (https://github.com/neutrinojs/webpack-chain#config-optimization-minimizers-adding) or downgrade to webpack-chain 4. If using Vue this likely means a Vue plugin has not yet been updated to support Vue CLI 4+.

Refs:
https://github.com/neutrinojs/webpack-chain/issues/204#issuecomment-570357470