### PR TITLE
Add missing engines definition to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "fluent",
     "api"
   ],
+  "engines": {
+    "node": ">=8"
+  },
   "files": [
     "src",
     "types/*.d.ts"


### PR DESCRIPTION
So that the versions supported and tested in CI are more obvious.

Support for Node.js 6 was previously dropped in webpack-chain 6.0.0.