### PR TITLE
Validate that Plugin 'args' is an array

### DIFF
--- a/src/Plugin.js
+++ b/src/Plugin.js
@@ -26,6 +26,13 @@ module.exports = Orderable(
       return this;
     }
 
+    set(key, value) {
+      if (key === 'args' && !Array.isArray(value)) {
+        throw new Error('args must be an array of arguments');
+      }
+      return super.set(key, value);
+    }
+
     merge(obj, omit = []) {
       if ('plugin' in obj) {
         this.set('plugin', obj.plugin);

--- a/test/Plugin.js
+++ b/test/Plugin.js
@@ -59,6 +59,30 @@ test('init', t => {
   t.deepEqual(initialized.values, ['gamma', 'delta']);
 });
 
+test('args is validated as being an array', t => {
+  const plugin = new Plugin();
+
+  t.throws(
+    () => plugin.use(StringifyPlugin, { foo: true }),
+    'args must be an array of arguments',
+  );
+
+  plugin.use(StringifyPlugin);
+
+  t.throws(
+    () => plugin.tap(() => ({ foo: true })),
+    'args must be an array of arguments',
+  );
+  t.throws(
+    () => plugin.merge({ args: 5000 }),
+    'args must be an array of arguments',
+  );
+  t.throws(
+    () => plugin.set('args', null),
+    'args must be an array of arguments',
+  );
+});
+
 test('toConfig', t => {
   const plugin = new Plugin(null, 'gamma');
 


### PR DESCRIPTION
Previously if `args` was set to something other than an array via any of `.use()`, `.tap()`, `.merge()` or `.set()`, that call would succeed but the later `.toConfig()` would fail with an unhelpful error message (when the `init` function tried to spread `args`).

Now validation is performed at the time `args` is set, with a more helpful error message and stack trace.

Fixes #121.