### PR TITLE
Add `devtoolNamespace` TypeScript declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,7 @@ config.output
   .devtoolFallbackModuleFilenameTemplate(devtoolFallbackModuleFilenameTemplate)
   .devtoolLineToLine(devtoolLineToLine)
   .devtoolModuleFilenameTemplate(devtoolModuleFilenameTemplate)
+  .devtoolNamespace(devtoolNamespace)
   .filename(filename)
   .hashFunction(hashFunction)
   .hashDigest(hashDigest)

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -113,6 +113,7 @@ declare namespace Config {
     devtoolFallbackModuleFilenameTemplate(value: any): this;
     devtoolLineToLine(value: any): this;
     devtoolModuleFilenameTemplate(value: any): this;
+    devtoolNamespace(value: string): this;
     globalObject(value: string): this;
     hashFunction(value: string): this;
     hashDigest(value: string): this;

--- a/types/test/webpack-chain-tests.ts
+++ b/types/test/webpack-chain-tests.ts
@@ -68,6 +68,7 @@ config
     .chunkLoadTimeout(1000)
     .crossOriginLoading(true)
     .devtoolFallbackModuleFilenameTemplate('')
+    .devtoolNamespace('')
     .devtoolLineToLine('')
     .devtoolModuleFilenameTemplate('')
     .filename('main.js')


### PR DESCRIPTION
Match implementation from https://github.com/neutrinojs/webpack-chain/blob/59dfdaf/src/Output.js