### PR TITLE
Adding config.set('singleEntry'). Resolves #230.

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,9 @@ config.entryPoints
 config.entryPoints
   .get(name)
     .clear()
+
+// Set entry to be a single value instead of a ChainedMap
+config.set('singleEntry', 'src/index.js')
 ```
 
 #### Config output: shorthand methods

--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ config.entryPoints
     .clear()
 
 // Set entry to be a single value instead of a ChainedMap
-config.set('singleEntry', 'src/index.js')
+config.set('singleEntry', entryPath)
 ```
 
 #### Config output: shorthand methods

--- a/src/Config.js
+++ b/src/Config.js
@@ -37,6 +37,7 @@ module.exports = class extends ChainedMap {
       'recordsInputPath',
       'recordsPath',
       'recordsOutputPath',
+      'singleEntry',
       'stats',
       'target',
       'watch',
@@ -117,6 +118,14 @@ module.exports = class extends ChainedMap {
   toConfig() {
     const entryPoints = this.entryPoints.entries() || {};
 
+    const entry = this.has('singleEntry')
+      ? this.get('singleEntry')
+      : Object.keys(entryPoints).reduce(
+          (acc, key) =>
+            Object.assign(acc, { [key]: entryPoints[key].values() }),
+          {},
+        );
+
     return this.clean(
       Object.assign(this.entries() || {}, {
         node: this.node.entries(),
@@ -128,11 +137,8 @@ module.exports = class extends ChainedMap {
         optimization: this.optimization.toConfig(),
         plugins: this.plugins.values().map(plugin => plugin.toConfig()),
         performance: this.performance.entries(),
-        entry: Object.keys(entryPoints).reduce(
-          (acc, key) =>
-            Object.assign(acc, { [key]: entryPoints[key].values() }),
-          {},
-        ),
+        entry,
+        singleEntry: undefined,
       }),
     );
   }

--- a/test/Config.js
+++ b/test/Config.js
@@ -61,6 +61,16 @@ test('entry', t => {
   ]);
 });
 
+test('single string entry', t => {
+  const config = new Config();
+
+  config.set('singleEntry', 'src/index.js');
+
+  t.deepEqual(config.toConfig(), {
+    entry: 'src/index.js',
+  });
+});
+
 test('plugin empty', t => {
   const config = new Config();
   const instance = config


### PR DESCRIPTION
Resolves #230.

`config.entryPoints` is a ChainedMap which doesn't translate well to situations where you want to set the webpack entry as a single string.

The `singleEntry` solution didn't feel the most elegant, but seemed better than overloading `config.entryPoints` or `config.entry()` to have additional methods that make them not behave as ChainedMaps. I'm open to other ideas about it, but think the `singleEntry` way is an alright one.