### PR TITLE
Add Types to Plugin Arguments

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -85,9 +85,15 @@ declare namespace Config {
   class Plugins<Parent, PluginType extends Tapable.Plugin = webpack.Plugin> extends TypedChainedMap<Parent, Plugin<Parent, PluginType>> {}
 
   class Plugin<Parent, PluginType extends Tapable.Plugin = webpack.Plugin> extends ChainedMap<Parent> implements Orderable {
-    init(value: (plugin: PluginType | PluginClass<PluginType>, args: any[]) => PluginType): this;
-    use(plugin: string | PluginType | PluginClass<PluginType>, args?: any[]): this;
-    tap(f: (args: any[]) => any[]): this;
+    init<P extends PluginType | PluginClass<PluginType>>(
+      value: (plugin: P, args: P extends PluginClass ? ConstructorParameters<P> : any[]
+    ) => PluginType): this;
+    use<P extends string | PluginType | PluginClass<PluginType>>(
+      plugin: P, args?: P extends PluginClass ? ConstructorParameters<P> : any[]
+    ): this;
+    tap<P extends PluginClass<PluginType>>(
+      f: (args: ConstructorParameters<P>) => ConstructorParameters<P>
+    ): this;
 
     // Orderable
     before(name: string): this;

--- a/types/test/webpack-chain-tests.ts
+++ b/types/test/webpack-chain-tests.ts
@@ -176,16 +176,22 @@ config
     .end()
 
   .plugin('foo')
-    .use(webpack.DefinePlugin, [])
+    .use(webpack.DefinePlugin, [{
+      'process.env.NODE_ENV': ""
+    }])
     .end()
 
   .plugin('bar')
-    .use(webpack.DefinePlugin, [])
+    .use(webpack.DefinePlugin, [{
+      'process.env.NODE_ENV': ""
+    }])
     .before('foo')
     .end()
 
   .plugin('baz')
-    .use(webpack.DefinePlugin, [])
+    .use(webpack.DefinePlugin, [{
+      'process.env.NODE_ENV': ""
+    }])
     .after('bar')
     .end()
 


### PR DESCRIPTION
Allows for proper typing of these functions.

```ts
...
  .plugin("html")
    .use(HtmlPlugin, [{
      // This is now properly typed, and will error on incorrect data
      inject: true,
      template: resolve("public/index.html"),
    }])
    
    // If a type is added to `plugin` `args` will have the proper types.
    .init((plugin: typeof HtmlPlugin, args) => args[0].cache)
    
    .tap<typeof HtmlPlugin>((args) => {
      args[0].cache // args is now typed
      return args
    })
```