### PR TITLE
Switch to a newer Travis base image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,10 @@
-dist: xenial
+dist: bionic
 language: node_js
 cache: yarn
 node_js:
 - '8'
 - '10'
 - '12'
-before_install:
-# Required due to: https://github.com/travis-ci/travis-ci/issues/7951
-- curl -sSfL https://yarnpkg.com/install.sh | bash
-- export PATH=$HOME/.yarn/bin:$PATH
 install:
 - yarn --frozen-lockfile
 script:


### PR DESCRIPTION
And remove the manual Yarn upgrade, since it's no longer required with the newer Travis image.