### PR TITLE
Test against Node 13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ node_js:
 - '8'
 - '10'
 - '12'
+- '13'
 install:
 - yarn --frozen-lockfile
 script:


### PR DESCRIPTION
webpack-chain already works with Node 13, but we weren't testing against it yet.