### PR TITLE
Drop support for Node 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,6 @@ node_js:
   - '10'
   - '12'
   - '14'
-jobs:
-  include:
-    # Prettier has dropped support for Node 8, so we have to skip linting and use --ignore-engines.
-    - node_js: 8
-      install:
-        - yarn --frozen-lockfile --ignore-engines
-      script:
-        - yarn test
-        - yarn test:types
 install:
   - yarn --frozen-lockfile
 script:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This is easier explained through the examples following.
 
 ## Installation
 
-`webpack-chain` requires Node.js 8 or higher. `webpack-chain` also only creates
+`webpack-chain` requires Node.js 10 or higher. `webpack-chain` also only creates
 configuration objects designed for use in webpack versions 2, 3, and 4.
 
 You may install this package using either Yarn or npm (choose one):

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "api"
   ],
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   },
   "files": [
     "src",


### PR DESCRIPTION
Since it's EOL:
https://nodejs.org/en/about/releases/

This is a breaking change so will need to be released in webpack-chain 7.