### PR TITLE
Drop documented support for webpack 3 and earlier

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 [![NPM downloads][npm-downloads]][npm-url]
 [![Build Status][travis-image]][travis-url]
 
-Use a chaining API to generate and simplify the modification of
-webpack version 2-4 configurations.
+Use a chaining API to generate and simplify the modification of webpack 4 configurations.
 
 This documentation corresponds to v6 of webpack-chain. For previous versions, see:
 
@@ -38,7 +37,7 @@ This is easier explained through the examples following.
 ## Installation
 
 `webpack-chain` requires Node.js 8 or higher. `webpack-chain` also only creates
-configuration objects designed for use in webpack versions 2, 3, and 4.
+configuration objects designed for use with webpack 4.
 
 You may install this package using either Yarn or npm (choose one):
 


### PR DESCRIPTION
We didn't test on anything other than webpack 4, so it's not clear what functionality still worked anyway. We'll also likely be needing to make a number of changes to webpack-chain to support webpack 5, so the fewer old versions of webpack we have to think about, the better.

webpack-chain doesn't have a peer dependency on webpack or we'd also adjust that (and for some use-cases a peer dep perhaps isn't appropriate, so I think we should leave that as is for now).

This is technically a breaking change so will be released in webpack-chain 7.