### PR TITLE
Travis: Test against Node 14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ cache: yarn
 node_js:
 - '10'
 - '12'
-- '13'
+- '14'
 jobs:
   include:
   # Prettier has dropped support for Node 8, so we have to skip linting and use --ignore-engines.


### PR DESCRIPTION
And remove Node 13 from the matrix since it's no longer supported and we still test against 12 and 14, which is good enough.

https://nodejs.org/en/about/releases/