### PR TITLE
Improve error message when .use() not called for a Plugin

### DIFF
--- a/src/Plugin.js
+++ b/src/Plugin.js
@@ -51,6 +51,12 @@ module.exports = Orderable(
       const args = this.get('args');
       let pluginPath = null;
 
+      if (plugin === undefined) {
+        throw new Error(
+          `Invalid ${this.type} configuration: ${this.type}('${this.name}').use(<Plugin>) was not called to specify the plugin`,
+        );
+      }
+
       // Support using the path to a plugin rather than the plugin itself,
       // allowing expensive require()s to be skipped in cases where the plugin
       // or webpack configuration won't end up being used.

--- a/test/Plugin.js
+++ b/test/Plugin.js
@@ -139,3 +139,11 @@ test('toConfig with plugin as path', () => {
   expect(initialized.__pluginConstructorName).toBe('EnvironmentPlugin');
   expect(initialized.__pluginPath).toBe(envPluginPath);
 });
+
+test('toConfig without having called use()', () => {
+  const plugin = new Plugin(null, 'gamma', 'optimization.minimizer');
+
+  expect(() => plugin.toConfig()).toThrow(
+    "Invalid optimization.minimizer configuration: optimization.minimizer('gamma').use(<Plugin>) was not called to specify the plugin",
+  );
+});


### PR DESCRIPTION
Previously if `.toConfig()` was called when a plugin was only partially configured, it raised with the unhelpful:

`TypeError: Cannot read property '__expression' of undefined`

Now the scenario results in an error of form:

`Error: Invalid plugin configuration: plugin('foo').use(<Plugin>) was not called to specify the plugin`

Or for minimizer plugins:

`Error: Invalid optimization.minimizer configuration: optimization.minimizer('foo').use(<Plugin>) was not called to specify the plugin`

Fixes scenario 1 in:
https://github.com/neutrinojs/webpack-chain/issues/204#issuecomment-570603495