### PR TITLE
Improve error message when .tap() used on an undefined plugin

### DIFF
--- a/src/Plugin.js
+++ b/src/Plugin.js
@@ -22,6 +22,11 @@ module.exports = Orderable(
     }
 
     tap(f) {
+      if (!this.has('plugin')) {
+        throw new Error(
+          `Cannot call .tap() on a plugin that has not yet been defined. Call ${this.type}('${this.name}').use(<Plugin>) first.`,
+        );
+      }
       this.set('args', f(this.get('args') || []));
       return this;
     }

--- a/test/Plugin.js
+++ b/test/Plugin.js
@@ -147,3 +147,11 @@ test('toConfig without having called use()', () => {
     "Invalid optimization.minimizer configuration: optimization.minimizer('gamma').use(<Plugin>) was not called to specify the plugin",
   );
 });
+
+test('tap() without having called use()', () => {
+  const plugin = new Plugin(null, 'gamma', 'optimization.minimizer');
+
+  expect(() => plugin.tap(() => [])).toThrow(
+    "Cannot call .tap() on a plugin that has not yet been defined. Call optimization.minimizer('gamma').use(<Plugin>) first.",
+  );
+});


### PR DESCRIPTION
Previously if `.tap()` was called for a plugin that didn't exist, the `.tap()` call would succeed, but the `.toConfig()` would fail later with:

`TypeError: Cannot read property '__expression' of undefined`

This scenario can typically occur when trying to customise a plugin added by a previous preset (where the preset only sometimes adds the plugin, such as in development), and forgetting to add a conditional using `.has()` before calling `.tap()`.

Whilst #270 changes that exception to a slightly more useful error message, it is still only shown at the time of the `.toConfig()`, where it's much harder to debug the cause.

Now the `.tap()` call itself will show the error:

`Error: Cannot call .tap() on a plugin that has not yet been defined. Call plugin('foo').use(<Plugin>) first`

Whilst this error check does technically break the (unlikely) scenario of calling `.tap()` in a preset before the plugin is defined by a later preset, IMO that ordering was already broken, since the `.tap()`'s args would have been overwritten by the subsequent preset.

Fixes #125.