### PR TITLE
Bump `main` to v7.0.0-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@
 
 Use a chaining API to generate and simplify the modification of webpack 4 configurations.
 
-This documentation corresponds to v6 of webpack-chain. For previous versions, see:
+This documentation corresponds to v7 of webpack-chain. For previous versions, see:
 
+* [v6 docs](https://github.com/neutrinojs/webpack-chain/tree/v6)
 * [v5 docs](https://github.com/neutrinojs/webpack-chain/tree/v5)
 * [v4 docs](https://github.com/neutrinojs/webpack-chain/tree/v4)
 * [v3 docs](https://github.com/neutrinojs/webpack-chain/tree/v3)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-chain",
-  "version": "6.5.1",
+  "version": "7.0.0-dev",
   "main": "src/Config.js",
   "typings": "types/index.d.ts",
   "repository": "neutrinojs/webpack-chain",


### PR DESCRIPTION
Since the next release will contain breaking changes so need to be a new major version.