### PR TITLE
Drop support for Node.js 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['10', '12', '14', '16']
+        node: ['12', '14', '16']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This is easier explained through the examples following.
 
 ## Installation
 
-`webpack-chain` requires Node.js 10 or higher. `webpack-chain` also only creates
+`webpack-chain` requires Node.js 12 or higher. `webpack-chain` also only creates
 configuration objects designed for use with webpack 4.
 
 You may install this package using either Yarn or npm (choose one):

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "api"
   ],
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "files": [
     "src",


### PR DESCRIPTION
Since it is EOL:
https://nodejs.org/en/about/releases/
https://endoflife.date/nodejs