### PR TITLE
support asset modules with generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1355,6 +1355,7 @@ config.merge({
         enforce,
         issuer,
         parser,
+        generator,
         resource,
         resourceQuery,
         test,

--- a/src/Rule.js
+++ b/src/Rule.js
@@ -34,6 +34,7 @@ const Rule = Orderable(
         'enforce',
         'issuer',
         'parser',
+        'generator',
         'resource',
         'resourceQuery',
         'sideEffects',

--- a/test/Rule.js
+++ b/test/Rule.js
@@ -505,3 +505,32 @@ test('ordered oneOfs', () => {
     /\.third$/,
   ]);
 });
+
+test('asset modules with generator and parser', () => {
+  const rule = new Rule();
+  rule
+    .rule('fonts')
+    .test(/\.tff$/)
+    .type('asset')
+    .generator({
+      filename: 'fonts/[hash][ext][query]',
+    })
+    .parser({
+      dataUrlCondition: {
+        maxSize: 4 * 1024,
+      },
+    });
+
+  expect(rule.toConfig().rules[0]).toStrictEqual({
+    test: /\.tff$/,
+    type: 'asset',
+    generator: {
+      filename: 'fonts/[hash][ext][query]',
+    },
+    parser: {
+      dataUrlCondition: {
+        maxSize: 4 * 1024,
+      },
+    },
+  });
+});


### PR DESCRIPTION
add generator config to custom asset filename will throw `UnhandledPromiseRejectionWarning: TypeError: config.module.rule(...).test(...).type(...).generator is not a function`
```js
config.modules
    .rule('fonts')
    .test(/\.tff$/)
    .type('asset')
    .generator({
      filename: 'fonts/[hash][ext][query]',
    })
    .parser({
      dataUrlCondition: {
        maxSize: 4 * 1024,
      },
    });
```